### PR TITLE
Use sbt-conductr to 2.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(DoubleIndentClassDeclaration, true)
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
-addSbtPlugin("me.lessis"        % "bintray-sbt" % "0.3.0")
-addSbtPlugin("com.typesafe.sbt" % "sbt-bundle"  % "1.2.1")
+addSbtPlugin("me.lessis"              % "bintray-sbt"  % "0.3.0")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/src/main/scala/com/typesafe/sbt/bintraybundle/BintrayBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bintraybundle/BintrayBundle.scala
@@ -2,8 +2,8 @@ package com.typesafe.sbt.bintraybundle
 
 import bintry.Licenses
 import sbt._
-import com.typesafe.sbt.bundle.SbtBundle, SbtBundle.autoImport._
-import com.typesafe.sbt.packager.universal.UniversalPlugin, UniversalPlugin.autoImport._
+import com.lightbend.conductr.sbt.BundlePlugin
+import com.typesafe.sbt.packager.universal.UniversalPlugin
 import bintray._
 
 /**
@@ -12,7 +12,10 @@ import bintray._
  */
 object BintrayBundle extends sbt.AutoPlugin {
 
-  override def `requires` = SbtBundle && BintrayPlugin
+  import UniversalPlugin.autoImport._
+  import BundlePlugin.autoImport._
+
+  override def `requires` = BundlePlugin && BintrayPlugin
   override def trigger = AllRequirements
 
   override def projectSettings: Seq[Setting[_]] =


### PR DESCRIPTION
Updates sbt-bundle to the new sbt-conductr 2.0.1 version that includes `sbt-bundle`. In the new version the class is named `BundlePlugin` instead of `SbtBundle`.
