### PR TITLE
Publish configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ means that the setting will be applied for the specific bundle.
 In addition, where a project has multiple bundle types and/or bundle configuration then bintray settings can be applied
 distinctly. Check out the sbt-bintray-bundle-tester sub project for an example.
 
-&copy; Typesafe Inc., 2015
+> Note that bundle configurations can also be published: `configuration:publish`. *Take care when publishing configurations* that contain sensitive data e.g. passwords and secrets. Ensure that the target repository on Bintray is protected by credentials. Note also that the configuration repo/package on Bintray will not default to the same repo/package as the bundle. Configuration is regarded as sensitive and so you must consider carefully where it lies.
+
+&copy; Lightbend Inc., 2015

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(PreserveDanglingCloseParenthesis, true)
 
 addSbtPlugin("me.lessis"              % "bintray-sbt"  % "0.3.0")
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.10")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.16")
 
 releaseSettings
 ReleaseKeys.versionBump := sbtrelease.Version.Bump.Minor

--- a/sbt-bintray-bundle-tester/build.sbt
+++ b/sbt-bintray-bundle-tester/build.sbt
@@ -16,7 +16,7 @@ BundleKeys.roles := Set("web-server")
 BundleKeys.configurationName := "frontend"
 
 lazy val BackendRegion = config("backend-region").extend(Bundle)
-SbtBundle.bundleSettings(BackendRegion)
+BundlePlugin.bundleSettings(BackendRegion)
 inConfig(BackendRegion)(Seq(
   normalizedName := "simple-test-backend"
 ))

--- a/src/sbt-test/sbt-bintray-bundle/basic/build.sbt
+++ b/src/sbt-test/sbt-bintray-bundle/basic/build.sbt
@@ -14,7 +14,7 @@ BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 BundleKeys.roles := Set("web-server")
 
-BundleKeys.configurationName := "frontend"
+BundleKeys.configurationName := "frontend-config"
 
 inConfig(Bundle)(Seq(
   bintrayVcsUrl := Some("https://github.com/sbt/sbt-bintray-bundle"),
@@ -26,6 +26,7 @@ val checkSettings = taskKey[Unit]("")
 
 checkSettings := {
   (bintrayPackage in Bundle).value shouldBe "simple-test-frontend"
+  (bintrayPackage in BundleConfiguration).value shouldBe "frontend-config"
 }
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
This commit permits bundle configuration to be published to bintray, as per the existing ability to publish bundles.

In addition a licensing check has been relaxed as that checks belongs to the server side.