### PR TITLE
Ensure configuration is published to the right dir

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bintraybundle/BintrayBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bintraybundle/BintrayBundle.scala
@@ -27,7 +27,12 @@ object BintrayBundle extends sbt.AutoPlugin {
   def settings(config: Configuration, isBundleConfiguration: Boolean = false): Seq[Setting[_]] =
     inConfig(config)(Seq(
       BintrayKeys.bintrayReleaseOnPublish in config := false,
-      BintrayKeys.bintrayRepository := "bundle",
+      BintrayKeys.bintrayRepository := {
+        if (isBundleConfiguration)
+          "bundle-configuration"
+        else
+          "bundle"
+      },
       Keys.publishMavenStyle := false,
       BintrayKeys.bintrayPackage := {
         if (isBundleConfiguration)


### PR DESCRIPTION
Bundle configuration is now published to a "bundle-configuration" directory by default.